### PR TITLE
CO-1563 - Update hostname config var

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ const config: IConfig = {
     ocr: 'ocr',
     original: 'orig'
   },
-  hostname: `${process.env.PROTOCOL}://${process.env.FILE_UPLOAD_SERVICE_URL}` || 'localhost',
+  hostname: `${process.env.PROTOCOL}${process.env.FILE_UPLOAD_SERVICE_URL}` || 'https://localhost',
   port: process.env.PORT || 8181,
   services: {
     keycloak: {


### PR DESCRIPTION
Remove `://` from the `hostname` config var as it's already in the `PROTOCOL` env var