### PR TITLE
CO-1563 - Add files to the url returned in the post response

### DIFF
--- a/src/controllers/PostResponseController.ts
+++ b/src/controllers/PostResponseController.ts
@@ -12,12 +12,12 @@ class PostResponseController {
 
   public response(req: Request, res: Response): Response {
     const {file, params} = req;
-    const {hostname, fileVersions} = this.config;
+    const {endpoints, fileVersions, hostname} = this.config;
     const responseParams: IPostResponseParams = {
       name: file.originalname,
       processedTime: file.processedTime,
       size: file.size,
-      url: `${hostname}/${params.businessKey}/${fileVersions.clean}/${file.filename}`
+      url: `${hostname}/${endpoints.files}/${params.businessKey}/${fileVersions.clean}/${file.filename}`
     };
     return res.status(201).json(responseParams);
   }

--- a/test/unit/src/controllers/PostResponseController.spec.ts
+++ b/test/unit/src/controllers/PostResponseController.spec.ts
@@ -32,7 +32,7 @@ describe('PostResponseController', () => {
         name: testFile.originalname,
         processedTime: testFile.processedTime,
         size: testFile.size,
-        url: `${config.hostname}/${req.params.businessKey}/${config.fileVersions.clean}/${testFile.filename}`
+        url: `${config.hostname}/${config.endpoints.files}/${req.params.businessKey}/${config.fileVersions.clean}/${testFile.filename}`
       });
 
       done();


### PR DESCRIPTION
The endpoint for getting an uploaded file requires `files` in the url and this is missing so this PR adds it in.

For example, from:

`https://localhost/abc-123/clean/be867103-3457-42fe-b026-3d315061e5d9`

to: 

`https://localhost/files/abc-123/clean/be867103-3457-42fe-b026-3d315061e5d9`

Also updated the unit tests.