### PR TITLE
CO-1563 - Remove the extra slash from the file url returned in the post response

### DIFF
--- a/src/controllers/PostResponseController.ts
+++ b/src/controllers/PostResponseController.ts
@@ -17,7 +17,7 @@ class PostResponseController {
       name: file.originalname,
       processedTime: file.processedTime,
       size: file.size,
-      url: `${hostname}/${endpoints.files}/${params.businessKey}/${fileVersions.clean}/${file.filename}`
+      url: `${hostname}${endpoints.files}/${params.businessKey}/${fileVersions.clean}/${file.filename}`
     };
     return res.status(201).json(responseParams);
   }

--- a/test/unit/src/controllers/PostResponseController.spec.ts
+++ b/test/unit/src/controllers/PostResponseController.spec.ts
@@ -32,7 +32,7 @@ describe('PostResponseController', () => {
         name: testFile.originalname,
         processedTime: testFile.processedTime,
         size: testFile.size,
-        url: `${config.hostname}/${config.endpoints.files}/${req.params.businessKey}/${config.fileVersions.clean}/${testFile.filename}`
+        url: `${config.hostname}${config.endpoints.files}/${req.params.businessKey}/${config.fileVersions.clean}/${testFile.filename}`
       });
 
       done();


### PR DESCRIPTION
Remove the extra slash after the hostname in the file url returned in the post response

Before:

`https://localhost//files/abc-123/clean/76035e8b-5691-4b98-9db9-c5fdb092e093`

After:

`https://localhost/files/abc-123/clean/76035e8b-5691-4b98-9db9-c5fdb092e093`

Also updated the unit tests