### PR TITLE
Change the delete route so that it is easier to call from the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,14 @@ filename: The name of the file to be downloaded
 ### Deleting a file
 
 ```
-DELETE /files/{businessKey}/{filename}
+DELETE /files/{businessKey}/{fileVersion}/{filename}
 ```
 
 #### Parameters
 
 businessKey: The business key of the process of the file to be deleted
+
+fileVersion: The version of the file to be downloaded. Will be one of: `orig`, `clean` or `ocr`
 
 filename: The name of the file to be deleted
 

--- a/src/routers/FilesRouter.ts
+++ b/src/routers/FilesRouter.ts
@@ -48,7 +48,7 @@ class FilesRouter {
     );
 
     router.delete(
-      `${config.endpoints.files}/:businessKey/:filename`,
+      `${config.endpoints.files}/:businessKey/:fileVersion/:filename`,
       new DeleteValidationController(joi).validateRoute,
       storageController.deleteFiles
     );

--- a/test/route/src/routers/FilesRouter.spec.ts
+++ b/test/route/src/routers/FilesRouter.spec.ts
@@ -166,6 +166,7 @@ describe('FilesRouter', () => {
 
   describe('delete()', () => {
     const deleteUrl = `${endpoints.files}/${businessKey}`;
+    const fileVersion = 'clean';
 
     it('should return the correct status and response', (done) => {
       nock(testS3Hostname)
@@ -174,7 +175,7 @@ describe('FilesRouter', () => {
 
       chai
         .request(app)
-        .delete(`${deleteUrl}/${filename}`)
+        .delete(`${deleteUrl}/${fileVersion}/${filename}`)
         .end((err: Error, res: superagent.Response) => {
           expect(res.status).to.equal(200);
           expect(res.body).to.deep.equal({message: 'Files deleted successfully'});
@@ -188,7 +189,7 @@ describe('FilesRouter', () => {
 
       chai
         .request(app)
-        .delete(`${deleteUrl}/${filename}`)
+        .delete(`${deleteUrl}/${fileVersion}/${filename}`)
         .end((err: Error, res: superagent.Response) => {
           expect(res.status).to.equal(500);
           expect(res.body).to.deep.equal({error: 'Failed to delete files'});
@@ -200,7 +201,7 @@ describe('FilesRouter', () => {
     it('should return the correct status and response when the route is not found', (done) => {
       chai
         .request(app)
-        .delete(`${deleteUrl}/does-not/exist`)
+        .delete(`${deleteUrl}/${filename}`)
         .end((err: Error, res: superagent.Response) => {
           expect(res.status).to.equal(404);
           expect(res.body).to.deep.equal({error: 'Route not found'});


### PR DESCRIPTION
The format has been changed to use the same format that is returned in the response from the initial upload, which includes the file version.

Changed from:

`https://localhost/BUSINESS_KEY/FILENAME`

To:

`https://localhost/BUSINESS_KEY/FILE_VERSION/FILENAME`