### PR TITLE
Update the delete route validation to expect a fileVersion param

### DIFF
--- a/src/validation/DeleteValidation.ts
+++ b/src/validation/DeleteValidation.ts
@@ -7,8 +7,11 @@ class DeleteValidation extends Validation {
       .object()
       .keys({
         businessKey: this.joi
-        .string()
-        .required(),
+          .string()
+          .required(),
+        fileVersion: this.joi
+          .string()
+          .required(),
         filename: this.joi
           .string()
           .regex(this.filenameRegex)

--- a/test/unit/src/validation/DeleteValidation.spec.ts
+++ b/test/unit/src/validation/DeleteValidation.spec.ts
@@ -3,8 +3,9 @@ import DeleteValidation from '../../../../src/validation/DeleteValidation';
 import {expect} from '../../../setupTests';
 
 interface ITestDeleteRequest {
-  filename: string | string[];
   businessKey: string | string[];
+  fileVersion: string | string[];
+  filename: string | string[];
 }
 
 describe('DeleteValidation', () => {
@@ -15,6 +16,7 @@ describe('DeleteValidation', () => {
   beforeEach(() => {
     data = {
       businessKey: 'BF-20191218-798',
+      fileVersion: 'clean',
       filename: '9e5eb809-bce7-463e-8c2f-b6bd8c4832d9'
     };
     schema = new DeleteValidation().schema();
@@ -38,6 +40,20 @@ describe('DeleteValidation', () => {
       delete data.businessKey;
       result = Joi.validate(data, schema);
       expect(result).to.have.property('error').and.match(/"businessKey" is required/);
+      done();
+    });
+
+    it('should return an error when fileVersion is not a string', (done) => {
+      data.fileVersion = ['clean'];
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"fileVersion" must be a string/);
+      done();
+    });
+
+    it('should return an error when fileVersion is not given', (done) => {
+      delete data.fileVersion;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"fileVersion" is required/);
       done();
     });
 


### PR DESCRIPTION
This change is needed because otherwise the delete route validation will not be expecting the `fileVersion` param and it will fail for requests using the new endpoint format.