### PR TITLE
CO-1550 - File Upload Service - Tidy up logging

### DIFF
--- a/src/utils/LogMessage.ts
+++ b/src/utils/LogMessage.ts
@@ -2,10 +2,12 @@ import {LogEntry} from 'winston';
 import ILogMessage from '../interfaces/ILogMessage';
 
 class LogMessage {
-  public static create(params: ILogMessage): LogEntry {
-    const {email, filename, message, level, timestamp}: ILogMessage = params;
+  public static create({email, filename, message, level, timestamp}: ILogMessage): LogEntry {
+    const logMessage: LogEntry = {filename, level: level || 'info', message};
 
-    const logMessage: LogEntry = { email: email || 'user@example.com', filename, level: level || 'info', message };
+    if (email) {
+      logMessage.email = email;
+    }
 
     if (timestamp) {
       logMessage.timestamp = timestamp;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -7,7 +7,7 @@ class Logger {
   private transports: any;
   private combine: any;
   private printf: any;
-  private prettyPrint: any;
+  private json: any;
   private timestamp: any;
 
   constructor(createLogger: any, format: any, transports: any) {
@@ -15,7 +15,7 @@ class Logger {
     this.transports = transports;
     this.combine = format.combine;
     this.printf = format.printf;
-    this.prettyPrint = format.prettyPrint;
+    this.json = format.json;
     this.timestamp = format.timestamp;
   }
 
@@ -32,7 +32,7 @@ class Logger {
       format: this.combine(
         this.timestamp(),
         this.outputFormat(),
-        this.prettyPrint()
+        this.json()
       ),
       transports: [
         new this.transports.Console()

--- a/test/unit/src/utils/LogMessage.spec.ts
+++ b/test/unit/src/utils/LogMessage.spec.ts
@@ -8,7 +8,7 @@ describe('LogMessage', () => {
   let message: string;
 
   beforeEach(() => {
-    email = 'user@example.com';
+    email = 'officer@homeoffice.gov.uk';
     filename = '9e5eb809-bce7-463e-8c2f-b6bd8c4832d9';
     message = 'File uploaded - orig version';
   });
@@ -42,7 +42,6 @@ describe('LogMessage', () => {
       const level: string = 'info';
       const logMessage: LogEntry = LogMessage.create({email, filename, message, level});
       expect(logMessage).to.deep.equal({
-        email: 'user@example.com',
         filename,
         level: 'info',
         message

--- a/test/unit/src/utils/Logger.spec.ts
+++ b/test/unit/src/utils/Logger.spec.ts
@@ -11,7 +11,7 @@ describe('Logger', () => {
     createLogger = sinon.spy();
     format = {
       combine: sinon.stub(),
-      prettyPrint: sinon.spy(),
+      json: sinon.spy(),
       printf: sinon.spy(),
       timestamp: sinon.stub().returns('a timestamp')
     };
@@ -59,7 +59,7 @@ describe('Logger', () => {
       expect(format.combine).to.have.been.calledOnce;
       expect(format.timestamp).to.have.been.calledOnce;
       expect(logger.outputFormat).to.have.been.calledOnce;
-      expect(format.prettyPrint).to.have.been.calledOnce;
+      expect(format.json).to.have.been.calledOnce;
       done();
     });
   });

--- a/test/unit/src/utils/Logger.spec.ts
+++ b/test/unit/src/utils/Logger.spec.ts
@@ -35,7 +35,7 @@ describe('Logger', () => {
   describe('formatMessage()', () => {
     it('should format a log message correctly when given a message as a string', (done) => {
       const params: ILogMessage = {
-        email: 'user@example.com',
+        email: 'officer@homeoffice.gov.uk',
         filename: '9e5eb809-bce7-463e-8c2f-b6bd8c4832d9',
         level: 'info',
         message: 'Virus scaning file',
@@ -44,7 +44,7 @@ describe('Logger', () => {
       const logger: Logger = new Logger(createLogger, format, transports);
       const message: string = logger.formatMessage(params);
       expect(message).to.equal(
-        `{"email":"${params.email}","filename":"${params.filename}","level":"${params.level}","message":"${params.message}","timestamp":"${params.timestamp}"}`
+        `{"filename":"${params.filename}","level":"${params.level}","message":"${params.message}","email":"${params.email}","timestamp":"${params.timestamp}"}`
       );
       done();
     });


### PR DESCRIPTION
Update logging so it displays correctly in Kibana.

Currently it's displayed on multiple lines:

```
{
  message: 'Listening on port 8181',
  level: 'info',
  timestamp: '2020-03-23T14:50:12.057Z'
}
```
and this has been updated to display on a single line.

```
{"message":"Listening on port 8181","level":"info","timestamp":"2020-03-23T14:50:41.549Z"}
```

Also removed the default email address so it's not displayed for log messages that don't require it, for example the health check.

Also updates unit tests.