### PR TITLE
Add the protocol to the URL returned in the POST response

### DIFF
--- a/src/controllers/PostResponseController.ts
+++ b/src/controllers/PostResponseController.ts
@@ -12,12 +12,12 @@ class PostResponseController {
 
   public response(req: Request, res: Response): Response {
     const {file, params} = req;
-    const {endpoints, fileVersions, hostname} = this.config;
+    const {endpoints, fileVersions, hostname, protocol} = this.config;
     const responseParams: IPostResponseParams = {
       name: file.originalname,
       processedTime: file.processedTime,
       size: file.size,
-      url: `${hostname}${endpoints.files}/${params.businessKey}/${fileVersions.clean}/${file.filename}`
+      url: `${protocol}${hostname}${endpoints.files}/${params.businessKey}/${fileVersions.clean}/${file.filename}`
     };
     return res.status(201).json(responseParams);
   }

--- a/test/unit/src/controllers/PostResponseController.spec.ts
+++ b/test/unit/src/controllers/PostResponseController.spec.ts
@@ -32,7 +32,7 @@ describe('PostResponseController', () => {
         name: testFile.originalname,
         processedTime: testFile.processedTime,
         size: testFile.size,
-        url: `${config.hostname}${config.endpoints.files}/${req.params.businessKey}/${config.fileVersions.clean}/${testFile.filename}`
+        url: `${config.protocol}${config.hostname}${config.endpoints.files}/${req.params.businessKey}/${config.fileVersions.clean}/${testFile.filename}`
       });
 
       done();


### PR DESCRIPTION
Add the protocol to the URL returned in the POST response otherwise the UI will treat the URL as a relative URL.

This is needed because without the protocol the URL is not a FQDN so the UI is treating this a relative URL and prepending the UI hostname to the beginning.

Therefore by adding the protocol to the beginning we're returning a FQDN and the UI will not change it.