### PR TITLE
CO-1840 - Errors with steps of uploading a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ The service performs the following actions on the uploaded files:
 - extracting text with ocr - valid files for ocr are: for .png, .jpg, .jpeg, .jpe, .tiff, .tif, .bmp, .pnm and .jfif
 - saving into storage - 3 file versions (`orig`, `clean` and `ocr`) are saved for most images and pdfs, 2 file versions (`orig` and `clean`) are saved for all other file types - currently S3 is supported
 
+The following file types can be uploaded:
+
+- doc
+- docx
+- gif
+- jpg
+- pdf
+- xls
+- xlsx
+
 ## Using the API
 
 ### Uploading a file

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const config: IConfig = {
   fileConversions: {
     pdfDensity: 300
   },
+  fileSizeLimitInBytes: 25000000,
   fileVersions: {
     clean: 'clean',
     ocr: 'ocr',

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,36 @@ const config: IConfig = {
       path: '/scan',
       port: process.env.VIRUS_SCAN_PORT || 8080
     }
+  },
+  validFileTypes: {
+    doc: {
+      mimetype: 'application/msword',
+      signature: 'd0cf11e0a1b11ae1'
+    },
+    docx: {
+      mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      signature: '504b0304'
+    },
+    gif: {
+      mimetype: 'image/gif',
+      signature: '47494638'
+    },
+    jpg: {
+      mimetype: 'image/jpeg',
+      signature: 'ffd8ffe0'
+    },
+    pdf: {
+      mimetype: 'application/pdf',
+      signature: '25504446'
+    },
+    xls: {
+      mimetype: 'application/vnd.ms-excel',
+      signature: 'd0cf11e0a1b11ae1'
+    },
+    xlsx: {
+      mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      signature: '504b0304'
+    }
   }
 };
 

--- a/src/controllers/DeleteValidationController.ts
+++ b/src/controllers/DeleteValidationController.ts
@@ -1,11 +1,10 @@
 import {NextFunction, Request, Response} from 'express';
 import {ValidationError} from 'joi';
-import DeleteValidation from '../validation/DeleteValidation';
 import ValidationController from './ValidationController';
 
 class DeleteValidationController extends ValidationController {
   public validateRoute(req: Request, res: Response, next: NextFunction): Response | void {
-    const error: ValidationError | null = this.validate.validateFields(new DeleteValidation(), this.joi, req.params);
+    const error: ValidationError | null = this.validate.validateFields(this.validator, this.joi, req.params);
     return this.handleValidation(req, res, next, error);
   }
 }

--- a/src/controllers/GetValidationController.ts
+++ b/src/controllers/GetValidationController.ts
@@ -1,16 +1,8 @@
 import {NextFunction, Request, Response} from 'express';
 import {ValidationError} from 'joi';
-import Validation from '../validation/Validation';
 import ValidationController from './ValidationController';
 
 class GetValidationController extends ValidationController {
-  private validator: Validation;
-
-  constructor(joi: any, validator: Validation) {
-    super(joi);
-    this.validator = validator;
-  }
-
   public validateRoute(req: Request, res: Response, next: NextFunction): Response | void {
     const error: ValidationError | null = this.validate.validateFields(this.validator, this.joi, req.params);
     return this.handleValidation(req, res, next, error);

--- a/src/controllers/PostValidationController.ts
+++ b/src/controllers/PostValidationController.ts
@@ -1,7 +1,6 @@
 import {NextFunction, Request, Response} from 'express';
 import {ValidationError} from 'joi';
 import IPostRequestParams from '../interfaces/IPostRequestParams';
-import PostValidation from '../validation/PostValidation';
 import ValidationController from './ValidationController';
 
 class PostValidationController extends ValidationController {
@@ -11,7 +10,7 @@ class PostValidationController extends ValidationController {
       businessKey: params.businessKey,
       file
     };
-    const error: ValidationError | null = this.validate.validateFields(new PostValidation(), this.joi, data);
+    const error: ValidationError | null = this.validate.validateFields(this.validator, this.joi, data);
     return this.handleValidation(req, res, next, error);
   }
 }

--- a/src/controllers/StorageController.ts
+++ b/src/controllers/StorageController.ts
@@ -48,12 +48,13 @@ class StorageController {
       file: fileToUpload
     };
 
-    logger(`Uploading file - ${fileToUpload.version} version`);
-
     try {
-      await this.storageService.uploadFile(uploadParams);
-      logger(`File uploaded - ${fileToUpload.version} version`);
-      delete allFiles[fileVersionToUpload];
+      if (fileToUpload) {
+        logger(`Uploading file - ${fileToUpload.version} version`);
+        await this.storageService.uploadFile(uploadParams);
+        logger(`File uploaded - ${fileToUpload.version} version`);
+        delete allFiles[fileVersionToUpload];
+      }
       return next();
     } catch (err) {
       logger(`Failed to upload file - ${fileToUpload.version} version`, 'error');

--- a/src/controllers/ValidationController.ts
+++ b/src/controllers/ValidationController.ts
@@ -1,13 +1,16 @@
 import {NextFunction, Request, Response} from 'express';
 import {JoiObject, ValidationError} from 'joi';
 import Validate from '../utils/Validate';
+import Validation from '../validation/Validation';
 
 class ValidationController {
   public validate: Validate;
   protected joi: JoiObject;
+  protected validator: Validation;
 
-  constructor(joi: any) {
+  constructor(joi: any, validator: Validation) {
     this.joi = joi;
+    this.validator = validator;
     this.validate = new Validate();
     this.validateRoute = this.validateRoute.bind(this);
   }

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -48,6 +48,7 @@ interface IConfig {
     xls: IValidFileType,
     xlsx: IValidFileType
   };
+  fileSizeLimitInBytes: number;
 }
 
 export default IConfig;

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -1,3 +1,5 @@
+import IValidFileType from './IValidFileType';
+
 interface IConfig {
   port: string | number;
   protocol: string;
@@ -36,6 +38,15 @@ interface IConfig {
   };
   fileConversions: {
     pdfDensity: number
+  };
+  validFileTypes: {
+    doc: IValidFileType,
+    docx: IValidFileType,
+    gif: IValidFileType,
+    jpg: IValidFileType,
+    pdf: IValidFileType,
+    xls: IValidFileType,
+    xlsx: IValidFileType
   };
 }
 

--- a/src/interfaces/IState.ts
+++ b/src/interfaces/IState.ts
@@ -1,0 +1,8 @@
+interface IState {
+  key: string;
+  parent: Express.Multer.File;
+  path: string[];
+  reference: string;
+}
+
+export default IState;

--- a/src/interfaces/IValidFileType.ts
+++ b/src/interfaces/IValidFileType.ts
@@ -1,0 +1,6 @@
+interface IValidFileType {
+  mimetype: string;
+  signature: string;
+}
+
+export default IValidFileType;

--- a/src/interfaces/IValidator.ts
+++ b/src/interfaces/IValidator.ts
@@ -1,0 +1,7 @@
+import IConfig from './IConfig';
+
+interface IValidator {
+  validate(joi: any, config: IConfig): any;
+}
+
+export default IValidator;

--- a/src/routers/FilesRouter.ts
+++ b/src/routers/FilesRouter.ts
@@ -1,6 +1,6 @@
 import * as express from 'express';
 import * as gm from 'gm';
-import * as joi from 'joi';
+import * as Joi from 'joi';
 import * as multer from 'multer';
 import * as ocr from 'tesseractocr';
 import * as util from 'util';
@@ -32,20 +32,20 @@ class FilesRouter {
 
     router.get(
       `${config.endpoints.files}/:businessKey/:fileVersion/:filename`,
-      new GetValidationController(joi, new GetFileValidation()).validateRoute,
+      new GetValidationController(Joi, new GetFileValidation()).validateRoute,
       storageController.downloadFile
     );
 
     router.get(
       `${config.endpoints.files}/:businessKey`,
-      new GetValidationController(joi, new GetFilesValidation()).validateRoute,
+      new GetValidationController(Joi, new GetFilesValidation()).validateRoute,
       storageController.listFiles
     );
 
     router.post(
       `${config.endpoints.files}/:businessKey`,
       upload.single('file'),
-      new PostValidationController(joi, new PostValidation()).validateRoute,
+      new PostValidationController(Joi, new PostValidation()).validateRoute,
       new MetadataController(Date.now(), config).generateMetadata,
       storageController.uploadFile,
       new VirusScanController(config).scanFile,
@@ -59,7 +59,7 @@ class FilesRouter {
 
     router.delete(
       `${config.endpoints.files}/:businessKey/:fileVersion/:filename`,
-      new DeleteValidationController(joi, new DeleteValidation()).validateRoute,
+      new DeleteValidationController(Joi, new DeleteValidation()).validateRoute,
       storageController.deleteFiles
     );
 

--- a/src/routers/FilesRouter.ts
+++ b/src/routers/FilesRouter.ts
@@ -16,8 +16,10 @@ import StorageController from '../controllers/StorageController';
 import VirusScanController from '../controllers/VirusScanController';
 import S3Service from '../services/S3Service';
 import FileConverter from '../utils/FileConverter';
+import DeleteValidation from '../validation/DeleteValidation';
 import GetFilesValidation from '../validation/GetFilesValidation';
 import GetFileValidation from '../validation/GetFileValidation';
+import PostValidation from '../validation/PostValidation';
 
 const storage: multer.StorageEngine = multer.memoryStorage();
 const upload: multer.Instance = multer({storage});
@@ -43,7 +45,7 @@ class FilesRouter {
     router.post(
       `${config.endpoints.files}/:businessKey`,
       upload.single('file'),
-      new PostValidationController(joi).validateRoute,
+      new PostValidationController(joi, new PostValidation()).validateRoute,
       new MetadataController(Date.now(), config).generateMetadata,
       storageController.uploadFile,
       new VirusScanController(config).scanFile,
@@ -57,7 +59,7 @@ class FilesRouter {
 
     router.delete(
       `${config.endpoints.files}/:businessKey/:fileVersion/:filename`,
-      new DeleteValidationController(joi).validateRoute,
+      new DeleteValidationController(joi, new DeleteValidation()).validateRoute,
       storageController.deleteFiles
     );
 

--- a/src/validation/PostValidation.ts
+++ b/src/validation/PostValidation.ts
@@ -11,6 +11,27 @@ class PostValidation extends Validation {
           .required(),
         file: this.joi
           .object()
+          .keys({
+            buffer: this.joi
+              .fileType()
+              .hex()
+              .required(),
+            encoding: this.joi
+              .string()
+              .required(),
+            fieldname: this.joi
+              .string()
+              .required(),
+            mimetype: this.joi
+              .string()
+              .required(),
+            originalname: this.joi
+              .string()
+              .required(),
+            size: this.joi
+              .number()
+              .required()
+          })
           .required()
       });
   }

--- a/src/validation/PostValidation.ts
+++ b/src/validation/PostValidation.ts
@@ -1,4 +1,5 @@
 import { ObjectSchema } from 'joi';
+import config from '../config';
 import Validation from './Validation';
 
 class PostValidation extends Validation {
@@ -30,6 +31,7 @@ class PostValidation extends Validation {
               .required(),
             size: this.joi
               .number()
+              .max(config.fileSizeLimitInBytes)
               .required()
           })
           .required()

--- a/src/validation/Validation.ts
+++ b/src/validation/Validation.ts
@@ -1,9 +1,24 @@
 import * as Joi from 'joi';
+import config from '../config';
+import FileTypeValidator from '../validation/validators/FileTypeValidator';
 
 class Validation {
   public filenamePattern: string = '([a-f0-9]{4,}-){4}[a-f0-9]{4,}';
   public filenameRegex: RegExp = new RegExp(`^${this.filenamePattern}$`);
-  protected joi: any = Joi;
+  public joi: any = this.extendedJoi();
+
+  public extendedJoi() {
+    let extendedJoi: any = Joi;
+    const validators: any = [
+      new FileTypeValidator()
+    ];
+
+    validators.forEach((validator: any): any => {
+      extendedJoi = extendedJoi.extend((joi: any): any => validator.validate(joi, config));
+    });
+
+    return extendedJoi;
+  }
 }
 
 export default Validation;

--- a/src/validation/validators/FileTypeValidator.ts
+++ b/src/validation/validators/FileTypeValidator.ts
@@ -1,0 +1,33 @@
+import IConfig from '../../interfaces/IConfig';
+import IState from '../../interfaces/IState';
+import IValidator from '../../interfaces/IValidator';
+import IValidFileType from '../../interfaces/IValidFileType';
+
+class FileTypeValidator implements IValidator {
+  public static signature(validFileTypes: IConfig['validFileTypes'], mimetype: string): string {
+    const file: Array<[string, IValidFileType]> = Object
+      .entries(validFileTypes)
+      .filter((type) => type[1].mimetype === mimetype);
+    return file.length ? file[0][1].signature : 'invalid';
+  }
+
+  public validate(joi: any, {validFileTypes}: IConfig) {
+    return {
+      base: joi.binary(),
+      language: {
+        hex: `file type is invalid, expecting one of ${Object.keys(validFileTypes).join(', ')}`
+      },
+      name: 'fileType',
+      rules: [{
+        name: 'hex',
+        validate(params: object, value: Buffer, state: IState, options: object): Buffer {
+          const fileHex: string = value.toString('hex');
+          const signature: string = FileTypeValidator.signature(validFileTypes, state.parent.mimetype);
+          return fileHex.startsWith(signature) ? value : joi.createError('fileType.hex', {value}, state, options);
+        }
+      }]
+    };
+  }
+}
+
+export default FileTypeValidator;

--- a/test/unit/src/controllers/DeleteValidationController.spec.ts
+++ b/test/unit/src/controllers/DeleteValidationController.spec.ts
@@ -7,6 +7,7 @@ import {expect, requestMock, responseMock, sinon, validateMock} from '../../../s
 describe('DeleteValidationController', () => {
   describe('validateRoute()', () => {
     it('should call validate.validateFields() and handleValidation()', (done) => {
+      const deleteValidation: DeleteValidation = new DeleteValidation();
       const req: Request = requestMock({
         params: {
           businessKey: 'BF-20191218-798',
@@ -15,7 +16,7 @@ describe('DeleteValidationController', () => {
       });
       const res: Response = responseMock({});
       const next: NextFunction = () => true;
-      const deleteValidationController: DeleteValidationController = new DeleteValidationController(Joi);
+      const deleteValidationController: DeleteValidationController = new DeleteValidationController(Joi, deleteValidation);
 
       deleteValidationController.validate = validateMock;
       const validateStub: sinon.SinonStub = sinon.stub(deleteValidationController.validate, 'validateFields').returns(null);
@@ -24,7 +25,7 @@ describe('DeleteValidationController', () => {
       deleteValidationController.validateRoute(req, res, next);
 
       expect(deleteValidationController.validate.validateFields).to.have.been.calledOnce;
-      expect(deleteValidationController.validate.validateFields).to.have.been.calledWith(new DeleteValidation(), Joi, req.params);
+      expect(deleteValidationController.validate.validateFields).to.have.been.calledWith(deleteValidation, Joi, req.params);
       expect(deleteValidationController.handleValidation).to.have.been.calledOnce;
       expect(deleteValidationController.handleValidation).to.have.been.calledWith(req, res, next, null);
 

--- a/test/unit/src/controllers/GetValidationController.spec.ts
+++ b/test/unit/src/controllers/GetValidationController.spec.ts
@@ -7,6 +7,7 @@ import {expect, requestMock, responseMock, sinon, validateMock} from '../../../s
 describe('GetFileValidationController', () => {
   describe('validateRoute()', () => {
     it('should call validate.validateFields() and handleValidation()', (done) => {
+      const getFileValidation: GetFileValidation = new GetFileValidation();
       const req: Request = requestMock({
         params: {
           businessKey: 'BF-20191218-798',
@@ -16,7 +17,7 @@ describe('GetFileValidationController', () => {
       });
       const res: Response = responseMock();
       const next: NextFunction = () => true;
-      const getValidationController: GetValidationController = new GetValidationController(Joi, new GetFileValidation());
+      const getValidationController: GetValidationController = new GetValidationController(Joi, getFileValidation);
 
       getValidationController.validate = validateMock;
       const validateStub: sinon.SinonStub = sinon
@@ -24,10 +25,10 @@ describe('GetFileValidationController', () => {
         .returns(null);
       getValidationController.handleValidation = sinon.spy();
 
-      getValidationController.validateRoute(req, res, next);
+      const result = getValidationController.validateRoute(req, res, next);
 
       expect(getValidationController.validate.validateFields).to.have.been.calledOnce;
-      expect(getValidationController.validate.validateFields).to.have.been.calledWith(new GetFileValidation(), Joi, req.params);
+      expect(getValidationController.validate.validateFields).to.have.been.calledWith(getFileValidation, Joi, req.params);
       expect(getValidationController.handleValidation).to.have.been.calledOnce;
       expect(getValidationController.handleValidation).to.have.been.calledWith(req, res, next, null);
 

--- a/test/unit/src/controllers/PostValidationController.spec.ts
+++ b/test/unit/src/controllers/PostValidationController.spec.ts
@@ -7,6 +7,7 @@ import {expect, requestMock, responseMock, sinon, testFile, validateMock} from '
 describe('PostValidationController', () => {
   describe('validateRoute()', () => {
     it('should call validate.validateFields() and handleValidation()', (done) => {
+      const postValidation: PostValidation = new PostValidation();
       const req: Request = requestMock({
         file: testFile,
         params: {
@@ -15,7 +16,7 @@ describe('PostValidationController', () => {
       });
       const res: Response = responseMock();
       const next: NextFunction = sinon.stub();
-      const postValidationController: PostValidationController = new PostValidationController(Joi);
+      const postValidationController: PostValidationController = new PostValidationController(Joi, postValidation);
 
       postValidationController.validate = validateMock;
       const validateStub: sinon.SinonStub = sinon.stub(postValidationController.validate, 'validateFields').returns(null);
@@ -24,10 +25,7 @@ describe('PostValidationController', () => {
       postValidationController.validateRoute(req, res, next);
 
       expect(postValidationController.validate.validateFields).to.have.been.calledOnce;
-      expect(postValidationController.validate.validateFields).to.have.been.calledWith(new PostValidation(), Joi, {
-        businessKey: 'BF-20191218-798',
-        file: testFile
-      });
+      expect(postValidationController.validate.validateFields).to.have.been.calledWith(postValidation);
       expect(postValidationController.handleValidation).to.have.been.calledOnce;
       expect(postValidationController.handleValidation).to.have.been.calledWith(req, res, next, null);
 

--- a/test/unit/src/validation/PostValidation.spec.ts
+++ b/test/unit/src/validation/PostValidation.spec.ts
@@ -1,9 +1,10 @@
+import * as fs from 'fs';
 import * as Joi from 'joi';
 import PostValidation from '../../../../src/validation/PostValidation';
 import {expect, testFile} from '../../../setupTests';
 
 interface ITestPostRequest {
-  file: Express.Multer.File | string;
+  file: any;
   businessKey: string | string[];
 }
 
@@ -15,7 +16,14 @@ describe('PostValidation', () => {
   beforeEach(() => {
     data = {
       businessKey: 'BF-20191218-798',
-      file: testFile
+      file: {
+        buffer: fs.readFileSync('test/data/test-file.pdf'),
+        encoding: '7bit',
+        fieldname: 'file',
+        mimetype: 'application/pdf',
+        originalname: 'test-file.pdf',
+        size: 100
+      }
     };
     schema = new PostValidation().schema();
   });
@@ -38,6 +46,90 @@ describe('PostValidation', () => {
       delete data.file;
       result = Joi.validate(data, schema);
       expect(result).to.have.property('error').and.match(/"file" is required/);
+      done();
+    });
+
+    it('should return an error when file buffer is not valid', (done) => {
+      data.file.mimetype = 'text/plain';
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"buffer" file type is invalid, expecting one of doc, docx, gif, jpg, pdf, xls, xlsx/);
+      done();
+    });
+
+    it('should return an error when file buffer is not given', (done) => {
+      delete data.file.buffer;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"buffer" is required/);
+      done();
+    });
+
+    it('should return an error when file encoding is not valid', (done) => {
+      data.file.encoding = 7;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"encoding" must be a string/);
+      done();
+    });
+
+    it('should return an error when file encoding is not given', (done) => {
+      delete data.file.encoding;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"encoding" is required/);
+      done();
+    });
+
+    it('should return an error when file fieldname is not valid', (done) => {
+      data.file.fieldname = {fieldname: 'file'};
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"fieldname" must be a string/);
+      done();
+    });
+
+    it('should return an error when file fieldname is not given', (done) => {
+      delete data.file.fieldname;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"fieldname" is required/);
+      done();
+    });
+
+    it('should return an error when file mimetype is not valid', (done) => {
+      data.file.mimetype = {mimetype: 'application/pdf'};
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"buffer" file type is invalid, expecting one of doc, docx, gif, jpg, pdf, xls, xlsx/);
+      done();
+    });
+
+    it('should return an error when file mimetype is not given', (done) => {
+      delete data.file.mimetype;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"buffer" file type is invalid, expecting one of doc, docx, gif, jpg, pdf, xls, xlsx/);
+      done();
+    });
+
+    it('should return an error when file originalname is not valid', (done) => {
+      data.file.originalname = {originalname: 'test-file.pdf'};
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"originalname" must be a string/);
+      done();
+    });
+
+    it('should return an error when file originalname is not given', (done) => {
+      delete data.file.originalname;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"originalname" is required/);
+      done();
+    });
+
+    it('should return an error when file size is not valid', (done) => {
+      data.file.size = {size: 100};
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"size" must be a number/);
+      done();
+    });
+
+    it('should return an error when file size is not given', (done) => {
+      delete data.file.size;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"size" is required/);
       done();
     });
 

--- a/test/unit/src/validation/PostValidation.spec.ts
+++ b/test/unit/src/validation/PostValidation.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as Joi from 'joi';
 import PostValidation from '../../../../src/validation/PostValidation';
-import {expect, testFile} from '../../../setupTests';
+import {config, expect} from '../../../setupTests';
 
 interface ITestPostRequest {
   file: any;
@@ -123,6 +123,13 @@ describe('PostValidation', () => {
       data.file.size = {size: 100};
       result = Joi.validate(data, schema);
       expect(result).to.have.property('error').and.match(/"size" must be a number/);
+      done();
+    });
+
+    it('should return an error when file size is greater than the max size', (done) => {
+      data.file.size = config.fileSizeLimitInBytes + 1;
+      result = Joi.validate(data, schema);
+      expect(result).to.have.property('error').and.match(/"size" must be less than or equal to 25000000/);
       done();
     });
 

--- a/test/unit/src/validation/Validation.spec.ts
+++ b/test/unit/src/validation/Validation.spec.ts
@@ -1,0 +1,24 @@
+import Validation from '../../../../src/validation/Validation';
+import {expect} from '../../../setupTests';
+
+describe('Validation', () => {
+  describe('class variables', () => {
+    it('should set the correct values', (done) => {
+      const validation = new Validation();
+      expect(validation.filenamePattern).to.equal('([a-f0-9]{4,}-){4}[a-f0-9]{4,}');
+      expect(validation.filenameRegex).to.deep.equal(new RegExp('^([a-f0-9]{4,}-){4}[a-f0-9]{4,}$'));
+      expect(validation.joi).to.have.property('isJoi').and.to.be.true;
+      done();
+    });
+  });
+
+  describe('extendedJoi()', () => {
+    it('should return an extended joi instance', (done) => {
+      const validation = new Validation();
+      const extendedJoi = validation.extendedJoi();
+      expect(extendedJoi).to.have.property('isJoi').and.to.be.true;
+      expect(extendedJoi).to.have.property('_binds').and.to.include('fileType');
+      done();
+    });
+  });
+});

--- a/test/unit/src/validation/validators/FileTypeValidator.spec.ts
+++ b/test/unit/src/validation/validators/FileTypeValidator.spec.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import * as joi from 'joi';
+import * as Joi from 'joi';
 import IState from '../../../../../src/interfaces/IState';
 import FileTypeValidator from '../../../../../src/validation/validators/FileTypeValidator';
 import {config, expect, testFile} from '../../../../setupTests';
@@ -24,7 +24,7 @@ describe('FileTypeValidator', () => {
   describe('validate()', () => {
     it('should return the correct params for the validator', (done) => {
       const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
-      const validator = fileTypeValidator.validate(joi, config);
+      const validator = fileTypeValidator.validate(Joi, config);
       expect(validator).to.have.property('language').and.to.deep.equal({
         hex: `file type is invalid, expecting one of ${Object.keys(config.validFileTypes).join(', ')}`
       });
@@ -49,7 +49,7 @@ describe('FileTypeValidator', () => {
 
       it('should return the value when the file is valid', (done) => {
         const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
-        const validator = fileTypeValidator.validate(joi, config);
+        const validator = fileTypeValidator.validate(Joi, config);
         const isValid = validator.rules[0].validate(params, value, state, options);
         expect(isValid).to.deep.equal(file);
         done();
@@ -58,7 +58,7 @@ describe('FileTypeValidator', () => {
       it('should return a joi error object when the file is invalid', (done) => {
         state.parent.mimetype = 'text/plain';
         const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
-        const validator = fileTypeValidator.validate(joi, config);
+        const validator = fileTypeValidator.validate(Joi, config);
         const isValid = validator.rules[0].validate(params, value, state, options);
         expect(isValid).to.deep.equal({
           context: {

--- a/test/unit/src/validation/validators/FileTypeValidator.spec.ts
+++ b/test/unit/src/validation/validators/FileTypeValidator.spec.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as joi from 'joi';
+import IState from '../../../../../src/interfaces/IState';
+import FileTypeValidator from '../../../../../src/validation/validators/FileTypeValidator';
+import {config, expect, testFile} from '../../../../setupTests';
+
+describe('FileTypeValidator', () => {
+  describe('signature()', () => {
+    it('should return the correct signature when the file type is valid', (done) => {
+      const mimetype: string = 'application/pdf';
+      const signature = FileTypeValidator.signature(config.validFileTypes, mimetype);
+      expect(signature).to.equal(config.validFileTypes.pdf.signature);
+      done();
+    });
+
+    it('should return invalid when the file type is invalid', (done) => {
+      const mimetype: string = 'text/plain';
+      const signature = FileTypeValidator.signature(config.validFileTypes, mimetype);
+      expect(signature).to.equal('invalid');
+      done();
+    });
+  });
+
+  describe('validate()', () => {
+    it('should return the correct params for the validator', (done) => {
+      const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
+      const validator = fileTypeValidator.validate(joi, config);
+      expect(validator).to.have.property('language').and.to.deep.equal({
+        hex: `file type is invalid, expecting one of ${Object.keys(config.validFileTypes).join(', ')}`
+      });
+      expect(validator).to.have.property('name').and.to.equal('fileType');
+      expect(validator).to.have.property('rules');
+      expect(validator.rules.length).to.equal(1);
+      expect(validator.rules[0]).to.have.property('name').and.to.equal('hex');
+      done();
+    });
+
+    describe('rules.validate()', () => {
+      const file: Buffer = fs.readFileSync('test/data/test-file.pdf');
+      const params: object = {};
+      const value: Buffer = file;
+      const state: IState = {
+        key: '',
+        parent: {...testFile, ...{mimetype: 'application/pdf'}},
+        path: [],
+        reference: ''
+      };
+      const options: object = {};
+
+      it('should return the value when the file is valid', (done) => {
+        const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
+        const validator = fileTypeValidator.validate(joi, config);
+        const isValid = validator.rules[0].validate(params, value, state, options);
+        expect(isValid).to.deep.equal(file);
+        done();
+      });
+
+      it('should return a joi error object when the file is invalid', (done) => {
+        state.parent.mimetype = 'text/plain';
+        const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
+        const validator = fileTypeValidator.validate(joi, config);
+        const isValid = validator.rules[0].validate(params, value, state, options);
+        expect(isValid).to.deep.equal({
+          context: {
+            key: undefined,
+            label: '',
+            value: file
+          },
+          flags: {},
+          isJoi: true,
+          message: undefined,
+          options: {},
+          path: [],
+          template: undefined,
+          type: 'fileType.hex'
+        });
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes a couple of issues with uploaded files:

**1. Word and Excel docs should be allowed to be uploaded but they are throwing an error.**

The reason for this was because these docs don't go through file conversion or OCR and because of this we weren't creating a `clean` version (having skipped the file conversion) and so the error was being thrown when the service tried to upload the non-existent `clean` version to S3. The fix was to:

1. As we don't have a `clean` version  for these files and this is the version that is downloaded for users, we're now saving the `orig` version as the `clean` version

2. Check if a file version exists before uploading it

**2. Missing file type validation was causing an error to be thrown by the OCR.**

The reason for this is similar to above but for the invalid files. The fix was to add file type validation by adding a custom validator that checks the magic number of the binary file to the validation library. This check is better than checking the file extension or mimetype as both of these can be easily faked by changing the file extension and we can be sure that the user is uploading a valid file type.

**3. Add max file size validation.**

The max file upload size is 25MB and we didn't have validation checking this so we do now.

**Other things to note**

New unit tests have been added and existing ones updated for the new functionality and a couple of missing ones were added to restore the test coverage.

Each part of this change has been split into separate logical commits so this would be much easier to review by commit rather than a single mass of changed files.