### PR TITLE
COP-703 - Case attachment showing incorrect date and time on "uploaded on" in Case View

### DIFF
--- a/src/controllers/MetadataController.ts
+++ b/src/controllers/MetadataController.ts
@@ -2,11 +2,9 @@ import {NextFunction, Request, Response} from 'express';
 import IConfig from '../interfaces/IConfig';
 
 class MetadataController {
-  protected processedTime: number;
   protected config: IConfig;
 
-  constructor(processedTime: number, config: IConfig) {
-    this.processedTime = processedTime;
+  constructor(config: IConfig) {
     this.config = config;
     this.generateMetadata = this.generateMetadata.bind(this);
   }
@@ -17,7 +15,7 @@ class MetadataController {
       ...{
         filename: req.uuid,
         originalMimeType: req.file.mimetype,
-        processedTime: this.processedTime,
+        processedTime: req.processedTime,
         version: this.config.fileVersions.original
       }
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ app.use(helmet());
 
 app.use((req, res, next) => {
   req.uuid = uuid();
+  req.processedTime = Date.now();
   next();
 });
 

--- a/src/routers/FilesRouter.ts
+++ b/src/routers/FilesRouter.ts
@@ -46,7 +46,7 @@ class FilesRouter {
       `${config.endpoints.files}/:businessKey`,
       upload.single('file'),
       new PostValidationController(Joi, new PostValidation()).validateRoute,
-      new MetadataController(Date.now(), config).generateMetadata,
+      new MetadataController(config).generateMetadata,
       storageController.uploadFile,
       new VirusScanController(config).scanFile,
       new FileConversionController(new FileConverter(gm, util, config), config).convertFile,

--- a/test/unit/src/controllers/MetadataController.spec.ts
+++ b/test/unit/src/controllers/MetadataController.spec.ts
@@ -8,11 +8,12 @@ describe('MetadataController', () => {
       const processedTime: number = Date.now();
       const req: Request = requestMock({
         file: testFile,
+        processedTime,
         uuid: '9e5eb809-bce7-463e-8c2f-b6bd8c4832d9'
       });
       const res: Response = responseMock();
       const next: NextFunction = sinon.spy();
-      const metadataController: MetadataController = new MetadataController(processedTime, config);
+      const metadataController: MetadataController = new MetadataController(config);
 
       metadataController.generateMetadata(req, res, next);
 

--- a/types/express/index.d.ts
+++ b/types/express/index.d.ts
@@ -3,7 +3,8 @@ declare module Express {
     allFiles: {[key: string]: Multer.File};
     logger: any;
     file: Multer.File;
-    uuid: any;
+    uuid: string;
+    processedTime: number;
     kauth: any;
   }
 


### PR DESCRIPTION
The issue is that uploaded files listed in Case View display an incorrect 'Uploaded on' date/time.

When files are uploaded a `processedTime` value was being passed into the `MetadataController` constructor from the router and then set to `req.file.processedTime` and eventually set as custom metadata when the file is uploaded.

The problem with this approach is that the date was being set when the service was started (with new kube pods) and then not changing when new files were uploaded and being saved incorrectly.

This change fixes that by setting the timestamp on `req.processedTime` using middelware and this will be run each time a file is uploaded and saved correctly.