### PR TITLE
COP-1236 - PDF uploading issue

### DIFF
--- a/kube/deployment.yml
+++ b/kube/deployment.yml
@@ -99,7 +99,7 @@ spec:
         ports:
           - containerPort: 8080
         env:
-           - name: CLAMAV_HOST
+           - name: CLAMD_HOST
              value: localhost
         resources:
           requests:


### PR DESCRIPTION
There appears to be an issue with uploading some pdf files but not others in dev. This is not an issue locally as all the files that fail to be uploaded in dev can be uploaded locally.

One difference in config is that locally there is a `CLAMD_HOST` env var for the `clamav-api` service and in dev this env var is called `CLAMAV_HOST`. The docs for the `clamav-api` service suggest that it should be `CLAMD_HOST`.

Changing `CLAMD_HOST` to `CLAMAV_HOST` locally gives a similar error to what can be seen in dev.

This PR changes the naming of the env var from `CLAMAV_HOST` to `CLAMD_HOST` to see that that fixes the issue in dev.