### PR TITLE
COP-1339 - Update File Upload Service to allow pgp files

### DIFF
--- a/src/validation/validators/FileTypeValidator.ts
+++ b/src/validation/validators/FileTypeValidator.ts
@@ -28,7 +28,8 @@ class FileTypeValidator implements IValidator {
     return {
       base: joi.binary(),
       language: {
-        invalid: `file type is invalid, valid formats are: ${Object.keys(validFileTypes).join(', ')}`
+        hex: `file type is invalid (hex), valid formats are: ${Object.keys(validFileTypes).join(', ')}`,
+        mime: `file type is invalid (mime), valid formats are: ${Object.keys(validFileTypes).join(', ')}`
       },
       name: 'fileType',
       rules: [{
@@ -39,13 +40,13 @@ class FileTypeValidator implements IValidator {
           );
           const fileHex: string = FileTypeValidator.fileHex(value, offset);
           const isValidHex = FileTypeValidator.isValidHex(fileHex, signature);
-          return isValidHex ? value : joi.createError('fileType.invalid', {value}, state, options);
+          return isValidHex ? value : joi.createError('fileType.hex', {value}, state, options);
         }
       }, {
         name: 'mime',
         validate(params: object, value: Buffer, state: IState, options: object): any {
           const isValidMimeType: boolean = FileTypeValidator.isValidMimeType(validFileTypes, state.parent.mimetype);
-          return isValidMimeType ? value : joi.createError('fileType.invalid', {value}, state, options);
+          return isValidMimeType ? value : joi.createError('fileType.mime', {value}, state, options);
         }
       }]
     };

--- a/test/unit/src/validation/PostValidation.spec.ts
+++ b/test/unit/src/validation/PostValidation.spec.ts
@@ -53,14 +53,14 @@ describe('PostValidation', () => {
     it('should return an error when file buffer has an invalid mime type', (done) => {
       data.file.mimetype = 'text/plain';
       result = Joi.validate(data, schema);
-      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid, valid formats are: ${validFileTypes}`));
+      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid \\(mime\\), valid formats are: ${validFileTypes}`));
       done();
     });
 
     it('should return an error when file buffer has an invalid hex signature', (done) => {
       data.file.buffer = fs.readFileSync('test/data/invalid-file-with-valid-ext.pdf');
       result = Joi.validate(data, schema);
-      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid, valid formats are: ${validFileTypes}`));
+      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid \\(hex\\), valid formats are: ${validFileTypes}`));
       done();
     });
 
@@ -102,14 +102,14 @@ describe('PostValidation', () => {
     it('should return an error when file mimetype is not valid', (done) => {
       data.file.mimetype = {mimetype: 'application/pdf'};
       result = Joi.validate(data, schema);
-      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid, valid formats are: ${validFileTypes}`));
+      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid \\(mime\\), valid formats are: ${validFileTypes}`));
       done();
     });
 
     it('should return an error when file mimetype is not given', (done) => {
       delete data.file.mimetype;
       result = Joi.validate(data, schema);
-      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid, valid formats are: ${validFileTypes}`));
+      expect(result).to.have.property('error').and.match(new RegExp(`"buffer" file type is invalid \\(mime\\), valid formats are: ${validFileTypes}`));
       done();
     });
 

--- a/test/unit/src/validation/validators/FileTypeValidator.spec.ts
+++ b/test/unit/src/validation/validators/FileTypeValidator.spec.ts
@@ -72,7 +72,8 @@ describe('FileTypeValidator', () => {
       const fileTypeValidator: FileTypeValidator = new FileTypeValidator();
       const validator = fileTypeValidator.validate(Joi, config);
       expect(validator).to.have.property('language').and.to.deep.equal({
-        invalid: `file type is invalid, valid formats are: ${Object.keys(config.validFileTypes).join(', ')}`
+        hex: `file type is invalid (hex), valid formats are: ${Object.keys(config.validFileTypes).join(', ')}`,
+        mime: `file type is invalid (mime), valid formats are: ${Object.keys(config.validFileTypes).join(', ')}`
       });
       expect(validator).to.have.property('name').and.to.equal('fileType');
       expect(validator).to.have.property('rules');
@@ -119,7 +120,7 @@ describe('FileTypeValidator', () => {
             options: {},
             path: [],
             template: undefined,
-            type: 'fileType.invalid'
+            type: 'fileType.hex'
           });
           done();
         });
@@ -151,7 +152,7 @@ describe('FileTypeValidator', () => {
             options: {},
             path: [],
             template: undefined,
-            type: 'fileType.invalid'
+            type: 'fileType.mime'
           });
           done();
         });


### PR DESCRIPTION
Currently we have the same error message returned when files are rejected because of their file type for both the mime and hex checks.

This change improves that by adding `mime` or `hex` to the error message so we can more clearly see which check is failing.