### PR TITLE
COP-1236 - PDF uploading issue

### DIFF
--- a/src/utils/FileConverter.ts
+++ b/src/utils/FileConverter.ts
@@ -17,7 +17,7 @@ class FileConverter {
 
   public initGm(file: File) {
     const {pdfDensity} = this.config.fileConversions;
-    const gm = this.gm(file.buffer, file.originalname);
+    const gm = this.gm(file.buffer, file.originalname).command('convert');
     return file.mimetype === 'application/pdf' ? gm.density(pdfDensity, pdfDensity) : gm;
   }
 
@@ -33,7 +33,7 @@ class FileConverter {
   public newMimeType(currentMimeType: string, originalMimeType: string): string[] {
     if (currentMimeType === originalMimeType) {
       const mimeTypeMap: {[key: string]: string[]} = {
-        'application/pdf': ['image/png', 'png'],
+        'application/pdf': ['image/tiff', 'tif'],
         'image/jpeg': ['image/png', 'png']
       };
       return mimeTypeMap[currentMimeType] || ['image/jpeg', 'jpeg'];

--- a/test/unit/src/utils/FileConverter.spec.ts
+++ b/test/unit/src/utils/FileConverter.spec.ts
@@ -8,8 +8,9 @@ describe('FileConverter', () => {
 
   beforeEach(() => {
     gm = sinon.stub().returns({
-      density: sinon.spy(),
-      toBuffer: sinon.spy()
+      command: sinon.stub().returnsThis(),
+      density: sinon.stub().returnsThis(),
+      toBuffer: sinon.stub().returnsThis()
     });
     util = {
       promisify: sinon.stub().returns(() => true)
@@ -71,7 +72,7 @@ describe('FileConverter', () => {
       const originalMimeType: string = 'application/pdf';
       const fileConverter: FileConverter = new FileConverter(gm, util, config);
       const newMimeType: string[] = fileConverter.newMimeType(currentMimeType, originalMimeType);
-      expect(newMimeType).to.deep.equal(['image/png', 'png']);
+      expect(newMimeType).to.deep.equal(['image/tiff', 'tif']);
       done();
     });
 


### PR DESCRIPTION
This change does the following:

- Update `FileConverter` to convert pdf files to tiff rather than png. This is needed because png files cannot contain multiple pages so after conversion a multiple page pdf files will only have the first page left, whereas tiff files can contain multiple pages so all the pages should remain.

- Explicitly call `convert`, which may help to fix the issue of some pdf files failing to upload in dev.