### PR TITLE
COP-1869 - File Upload Service - Improve jpg validation 

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,114 +50,114 @@ const config: IConfig = {
   validFileTypes: {
     avi: {
       mimetype: 'video/x-msvideo',
-      signature: '52494646'
+      signatures: ['52494646']
     },
     doc: {
       mimetype: 'application/msword',
-      signature: 'd0cf11e0a1b11ae1'
+      signatures: ['d0cf11e0a1b11ae1']
     },
     docx: {
       mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      signature: '504b0304'
+      signatures: ['504b0304']
     },
     dot: {
       mimetype: 'application/msword',
-      signature: 'd0cf11e0a1b11ae1'
+      signatures: ['d0cf11e0a1b11ae1']
     },
     eps: {
       mimetype: 'application/postscript',
-      signature: '252150532d41646f'
+      signatures: ['252150532d41646f']
     },
     flv: {
       mimetype: 'video/x-flv',
-      signature: '464c56'
+      signatures: ['464c56']
     },
     gif: {
       mimetype: 'image/gif',
-      signature: '47494638'
+      signatures: ['47494638']
     },
     gpg: {
       mimetype: 'application/octet-stream',
-      signature: '85'
+      signatures: ['85']
     },
     jpg: {
       mimetype: 'image/jpeg',
-      signature: 'ffd8ffe0'
+      signatures: ['ffd8ffe0', 'ffd8ffe1']
     },
     m4v: {
       mimetype: 'video/x-m4v',
       offset: 8,
-      signature: '667479704d345620'
+      signatures: ['667479704d345620']
     },
     mov: {
       mimetype: 'video/quicktime',
       offset: 8,
-      signature: '6674797071742020'
+      signatures: ['6674797071742020']
     },
     mp3: {
       mimetype: 'audio/mpeg',
-      signature: '494433'
+      signatures: ['494433']
     },
     odp: {
       mimetype: 'application/vnd.oasis.opendocument.presentation',
-      signature: '504b0304'
+      signatures: ['504b0304']
     },
     odt: {
       mimetype: 'application/vnd.oasis.opendocument.text',
-      signature: '504b0304'
+      signatures: ['504b0304']
     },
     oga: {
       mimetype: 'audio/ogg',
-      signature: '4f67675300020000'
+      signatures: ['4f67675300020000']
     },
     ogg: {
       mimetype: 'audio/ogg',
-      signature: '4f67675300020000'
+      signatures: ['4f67675300020000']
     },
     ogv: {
       mimetype: 'video/ogg',
-      signature: '4f67675300020000'
+      signatures: ['4f67675300020000']
     },
     pdf: {
       mimetype: 'application/pdf',
-      signature: '25504446'
+      signatures: ['25504446']
     },
     pgp: {
       mimetype: 'application/pgp-encrypted',
       offset: 4,
-      signature: '504750'
+      signatures: ['504750']
     },
     png: {
       mimetype: 'image/png',
-      signature: '89504e470d0a1a0a'
+      signatures: ['89504e470d0a1a0a']
     },
     pps: {
       mimetype: 'application/vnd.ms-powerpoint',
-      signature: 'd0cf11e0a1b11ae1'
+      signatures: ['d0cf11e0a1b11ae1']
     },
     ppt: {
       mimetype: 'application/vnd.ms-powerpoint',
-      signature: 'd0cf11e0a1b11ae1'
+      signatures: ['d0cf11e0a1b11ae1']
     },
     pptx: {
       mimetype: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      signature: '504b0304'
+      signatures: ['504b0304']
     },
     rtf: {
       mimetype: 'application/rtf',
-      signature: '7b5c72746631'
+      signatures: ['7b5c72746631']
     },
     tif: {
       mimetype: 'image/tiff',
-      signature: '49492a00'
+      signatures: ['49492a00']
     },
     xls: {
       mimetype: 'application/vnd.ms-excel',
-      signature: 'd0cf11e0a1b11ae1'
+      signatures: ['d0cf11e0a1b11ae1']
     },
     xlsx: {
       mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      signature: '504b0304'
+      signatures: ['504b0304']
     }
   }
 };

--- a/src/interfaces/IValidFileType.ts
+++ b/src/interfaces/IValidFileType.ts
@@ -1,6 +1,6 @@
 interface IValidFileType {
   mimetype: string;
-  signature: string;
+  signatures: string[];
   offset?: number;
 }
 

--- a/src/validation/validators/FileTypeValidator.ts
+++ b/src/validation/validators/FileTypeValidator.ts
@@ -27,9 +27,9 @@ class FileTypeValidator implements IValidator {
     return !offset ? fileHex : fileHex.substr(offset, fileHex.length);
   }
 
-  public static isValidHex(value: Buffer, offset: number | undefined, signature: string): boolean {
+  public static isValidHex(value: Buffer, offset: number | undefined, signatures: string[]): boolean {
     const fileHex: string = FileTypeValidator.fileHex(value, offset);
-    return fileHex.startsWith(signature);
+    return signatures.some((signature: string): boolean => fileHex.startsWith(signature));
   }
 
   public static isValidMimeType(validFileTypes: IConfig['validFileTypes'], fileMimeType: string): boolean {
@@ -52,19 +52,19 @@ class FileTypeValidator implements IValidator {
         name: 'hex',
         validate(params: object, value: Buffer, state: IState, options: object): any {
           const validator = FileTypeValidator;
-          let signature: string;
+          let signatures: string[];
           let offset: number | undefined;
-          ({signature, offset} = validator.validFileProps(
+          ({signatures, offset} = validator.validFileProps(
             validFileTypes, validator.mimeFilter(state.parent.mimetype)
           ));
-          let isValidHex: boolean = validator.isValidHex(value, offset, signature);
+          let isValidHex: boolean = validator.isValidHex(value, offset, signatures);
 
           if (!isValidHex) {
             const fileExtension = validator.fileExtension(state.parent.originalname);
-            ({signature, offset} = validator.validFileProps(
+            ({signatures, offset} = validator.validFileProps(
               validFileTypes, validator.extensionFilter(fileExtension)
             ));
-            isValidHex = validator.isValidHex(value, offset, signature);
+            isValidHex = validator.isValidHex(value, offset, signatures);
           }
 
           return isValidHex ? value : joi.createError('fileType.hex', {value}, state, options);

--- a/test/unit/src/validation/validators/FileTypeValidator.spec.ts
+++ b/test/unit/src/validation/validators/FileTypeValidator.spec.ts
@@ -75,15 +75,15 @@ describe('FileTypeValidator', () => {
     const offset: number = 0;
 
     it('should return true when the file hex is valid', (done) => {
-      const signature: string = '32353530';
-      const isValidHex: boolean = FileTypeValidator.isValidHex(value, offset, signature);
+      const signatures: string[] = ['32353530', '504b0304'];
+      const isValidHex: boolean = FileTypeValidator.isValidHex(value, offset, signatures);
       expect(isValidHex).to.be.true;
       done();
     });
 
     it('should return false when the file hex is invalid', (done) => {
-      const signature: string = '504b0304';
-      const isValidHex: boolean = FileTypeValidator.isValidHex(value, offset, signature);
+      const signatures: string[] = ['504b0304', '932ab8c1'];
+      const isValidHex: boolean = FileTypeValidator.isValidHex(value, offset, signatures);
       expect(isValidHex).to.be.false;
       done();
     });


### PR DESCRIPTION
When a file is uploaded we are validating the file hex string against a signature to ensure that the file is of the correct type.

Previously this was done by comparing the file hex to a string signature but this only allowed us to validate against a single signature. This was causing an issue with jpg files uploaded from a phone camera because jpgs generated by a phone camera have a different signature to jpgs created on a computer.

This change fixes this issue by updating `FileTypeValidator` to validate the file hex with an array of signatures rather than a single string.