### PR TITLE
Allow uploading of csv files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently S3 is supported for storage
 The following file types can be uploaded:
 
 - avi
+- csv
 - doc
 - docx
 - dot

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,10 @@ const config: IConfig = {
       mimetype: 'video/x-msvideo',
       signatures: ['52494646']
     },
+    csv: {
+      mimetype: 'text/csv',
+      signatures: []
+    },
     doc: {
       mimetype: 'application/msword',
       signatures: ['d0cf11e0a1b11ae1']

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -41,6 +41,7 @@ interface IConfig {
   };
   validFileTypes: {
     avi: IValidFileType,
+    csv: IValidFileType,
     doc: IValidFileType,
     docx: IValidFileType,
     dot: IValidFileType,

--- a/src/validation/validators/FileTypeValidator.ts
+++ b/src/validation/validators/FileTypeValidator.ts
@@ -29,7 +29,7 @@ class FileTypeValidator implements IValidator {
 
   public static isValidHex(value: Buffer, offset: number | undefined, signatures: string[]): boolean {
     const fileHex: string = FileTypeValidator.fileHex(value, offset);
-    return signatures.some((signature: string): boolean => fileHex.startsWith(signature));
+    return signatures.length ? signatures.some((signature: string): boolean => fileHex.startsWith(signature)) : true;
   }
 
   public static isValidMimeType(validFileTypes: IConfig['validFileTypes'], fileMimeType: string): boolean {

--- a/test/unit/src/validation/validators/FileTypeValidator.spec.ts
+++ b/test/unit/src/validation/validators/FileTypeValidator.spec.ts
@@ -81,6 +81,13 @@ describe('FileTypeValidator', () => {
       done();
     });
 
+    it('should return true when no signatures are specified', (done) => {
+      const signatures: string[] = [];
+      const isValidHex: boolean = FileTypeValidator.isValidHex(value, offset, signatures);
+      expect(isValidHex).to.be.true;
+      done();
+    });
+
     it('should return false when the file hex is invalid', (done) => {
       const signatures: string[] = ['504b0304', '932ab8c1'];
       const isValidHex: boolean = FileTypeValidator.isValidHex(value, offset, signatures);


### PR DESCRIPTION
The magic number check is bypassed for `csv` files as there isn't a common signature to check against.

This is done by using an empty `signatures` array in the config and checking if this is empty before doing the magic number check. If the array is empty then we bypass the check and if it's not empty then the check is done.

This also gives us an easy way to bypass the magic number check for other files if necessary in the future.