### PR TITLE
Update virus scan url

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ const config: IConfig = {
     virusScan: {
       host: process.env.VIRUS_SCAN_HOST || 'localhost',
       path: '/scan',
-      port: process.env.VIRUS_SCAN_PORT || 8080
+      port: process.env.VIRUS_SCAN_PORT
     }
   },
   validFileTypes: {

--- a/src/controllers/VirusScanController.ts
+++ b/src/controllers/VirusScanController.ts
@@ -13,15 +13,16 @@ class VirusScanController {
   public async scanFile(req: Request, res: Response, next: NextFunction): Promise<Response | void> {
     const {file, logger} = req;
     const {services} = this.config;
-    const {virusScan} = services;
+    const {host, path, port} = services.virusScan;
+    const url = `${host}${port ? `:${port}` : ''}${path}`;
     logger('Virus scanning file');
-    logger(`url = http://${virusScan.host}:${virusScan.port}${virusScan.path}`, 'debug');
+    logger(`url = ${url}`, 'debug');
     logger(`file.buffer.length = ${file.buffer.length}`, 'debug');
     logger(`file.originalname = ${file.originalname}`, 'debug');
 
     try {
       const result = await request
-        .post(`http://${virusScan.host}:${virusScan.port}${virusScan.path}`)
+        .post(url)
         .attach('file', file.buffer, file.originalname)
         .field('name', file.originalname);
 

--- a/src/interfaces/IConfig.ts
+++ b/src/interfaces/IConfig.ts
@@ -12,7 +12,7 @@ interface IConfig {
   services: {
     virusScan: {
       host: string,
-      port: string | number,
+      port: string | number | undefined,
       path: string
     },
     s3: {

--- a/test/unit/src/controllers/VirusScanController.spec.ts
+++ b/test/unit/src/controllers/VirusScanController.spec.ts
@@ -14,7 +14,7 @@ describe('VirusScanController', () => {
 
     beforeEach(() => {
       const {virusScan}: IConfig['services'] = config.services;
-      virusScanMock = nock(`http://${virusScan.host}:${virusScan.port}`).post(virusScan.path);
+      virusScanMock = nock(`http://${virusScan.host}`).post(virusScan.path);
 
       req = requestMock({
         file: testFile,


### PR DESCRIPTION
Check the if the virus scan port exists before using it and remove the hard-coded virus scan url protocol